### PR TITLE
Bringing examples into line with cleanup of vm6502q

### DIFF
--- a/grover_lookup_asm/grover_lookup_asm.s
+++ b/grover_lookup_asm/grover_lookup_asm.s
@@ -6,6 +6,7 @@
 GINIT:	clq
 		ldy #$0c
 		ldx #$00
+		seq
 		hax
 		lda $0f00,X
 		cln


### PR DESCRIPTION
A small change in one example is necessary for new logic in vm6502q. (See https://github.com/vm6502q/vm6502q/pull/9 )